### PR TITLE
Update platform.txt

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -22,6 +22,12 @@
 name=Raspberry Pi RP2040 Boards
 version=3.3.1
 
+# Required discoveries and monitors
+# ---------------------------------
+pluggable_discovery.required.0=builtin:serial-discovery
+pluggable_discovery.required.1=builtin:mdns-discovery
+pluggable_monitor.required.serial=builtin:serial-monitor
+
 runtime.tools.pqt-gcc.path={runtime.platform.path}/system/arm-none-eabi
 runtime.tools.pqt-python3.path={runtime.platform.path}/system/python3
 runtime.tools.pqt-mklittlefs.path={runtime.platform.path}/system/mklittlefs


### PR DESCRIPTION
Requiring the auto-discovery tool and serial monitor if they have not already been included by other boards (namely if AVR cores have been uinstalled in the IDE).